### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: java
 jdk:
-  - oraclejdk7
+  - oraclejdk8
 
 notifications:
   email:


### PR DESCRIPTION
Travis no longer supports java7. Even with this change some dependency issue is blocking the build. See https://travis-ci.org/priitliivak/j-road/builds/282220234